### PR TITLE
WIP Add CurlHandle support

### DIFF
--- a/src/CurlRequest.php
+++ b/src/CurlRequest.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
 class CurlRequest implements HttpRequest {
 
 	/**
-	 * @var resource
+	 * @var resource|CurlHandle
 	 */
 	private $handle;
 
@@ -25,11 +25,16 @@ class CurlRequest implements HttpRequest {
 	/**
 	 * @since 1.0
 	 *
-	 * @param resource $handle
+	 * @param resource|CurlHandle|false $handle
 	 */
 	public function __construct( $handle ) {
 
-		if ( get_resource_type( $handle ) !== 'curl' ) {
+		// PHP 8.0
+		$isCurlHandle = class_exists( '\CurlHandle' ) && $handle instanceof \CurlHandle;
+
+		// PHP 7
+		if ( $handle === false ||
+			( !$isCurlHandle && get_resource_type( $handle ) !== 'curl' ) ) {
 			throw new InvalidArgumentException( "Expected a cURL resource type" );
 		}
 


### PR DESCRIPTION
Semantic MediaWiki PHP 8 tests are failing because `resource` was replaced by `CurlHandle`.
SMW issue: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5346

This is a hacky, partially tested fix. It makes the SMW CURL errors go away on PHP 8, though.
It's partially manually tested, because the unit tests are using ancient PHPUnit stuff which requires more fixes.

This could go into a release 1.4.0. The alternative proper solution is to start version 2.0.0 which supports only PHP 8.0+. SMW will then have to require either 2.x or 1.x.